### PR TITLE
Add trade api and some api for leverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ api.ticker(function(body) {
         console.log(body);
     }
 )
+
+api.trades(offset, function(body) {
+        console.log(body);
+    }
+)
 ```
 
 ## Private API
@@ -39,6 +44,22 @@ then(function(config){
         }
     );
     api.cancelOrder(5910927, function(body) {
+            console.log(body);
+        }
+    );
+
+    // for leverage
+    api.getLeverageBalance(function(body){
+            console.log(body);
+        }
+    );
+
+    api.exchangeToLeverage('JPY', 10000, function(body){
+            console.log(body);
+        }
+    );
+
+    api.exchangeFromLeverage('JPY', 10000, function(body){
             console.log(body);
         }
     );

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ then(function(config){
         }
     );
 
-    api.exchangeToLeverage('JPY', 10000, function(body){
+    api.transferToLeverage('JPY', 10000, function(body){
             console.log(body);
         }
     );
 
-    api.exchangeFromLeverage('JPY', 10000, function(body){
+    api.transferFromLeverage('JPY', 10000, function(body){
             console.log(body);
         }
     );

--- a/lib/private_api.js
+++ b/lib/private_api.js
@@ -84,13 +84,13 @@ var createPrivateApi = module.exports = function(api_key, secret_key, user_agent
             var params = querystring.stringify({"status": status});
             return get_query('/exchange/leverage/positions' + params , {}, callback)
         },
-        exchangeToLeverage: function(currency, amount, callback){
+        transferToLeverage: function(currency, amount, callback){
             return post_query('/exchange/transfers/to_leverage', {
                 currency : currency,
                 amount : amount
             }, callback)
         },
-        exchangeFromLeverage: function(currency, amount, callback){
+        transferFromLeverage: function(currency, amount, callback){
             return post_query('/exchange/transfers/from_leverage', {
                 currency : currency,
                 amount : amount

--- a/lib/private_api.js
+++ b/lib/private_api.js
@@ -79,6 +79,15 @@ var createPrivateApi = module.exports = function(api_key, secret_key, user_agent
         cancelOrder : function(order_id, callback){
             return delete_query('/exchange/orders/' +  order_id, {}, callback)
         },
+        closeTrade : function(currency_pair, action, price, amount, position_id, callback){
+            return post_query('/exchange/orders', {
+                pair : currency_pair,
+                order_type : action,
+                rate : price,
+                amount : amount,
+                position_id : position_id
+            }, callback)
+        },
         getLeverageBalance: function(callback){ return get_query('/accounts/leverage_balance', {}, callback) },
         getLeveragePositions: function(status, callback){
             var params = querystring.stringify({"status": status});

--- a/lib/private_api.js
+++ b/lib/private_api.js
@@ -79,6 +79,23 @@ var createPrivateApi = module.exports = function(api_key, secret_key, user_agent
         cancelOrder : function(order_id, callback){
             return delete_query('/exchange/orders/' +  order_id, {}, callback)
         },
+        getLeverageBalance: function(callback){ return get_query('/accounts/leverage_balance', {}, callback) },
+        getLeveragePositions: function(status, callback){
+            var params = querystring.stringify({"status": status});
+            return get_query('/exchange/leverage/positions' + params , {}, callback)
+        },
+        exchangeToLeverage: function(currency, amount, callback){
+            return post_query('/exchange/transfers/to_leverage', {
+                currency : currency,
+                amount : amount
+            }, callback)
+        },
+        exchangeFromLeverage: function(currency, amount, callback){
+            return post_query('/exchange/transfers/from_leverage', {
+                currency : currency,
+                amount : amount
+            }, callback)
+        }
     };
 }
 

--- a/lib/public_api.js
+++ b/lib/public_api.js
@@ -13,6 +13,16 @@ exports.ticker = function(callback){
     });
 }
 
+exports.trades = function(offset, callback){
+    request.get({url: constant.OPT_API_URL + '/trades?offset=' + offset}, function(error, response, body){
+        if (!error && response.statusCode == 200) {
+            callback(JSON.parse(body));
+        } else {
+            console.log('error: '+ response.statusCode);
+        }
+    });
+}
+
 exports.depth = function(callback){
     request.get({url: constant.OPT_API_URL + '/order_books'}, function(error, response, body){
         if (!error && response.statusCode == 200) {


### PR DESCRIPTION
Adding below APIs
- Public
  - 全取引履歴 GET /api/trades
- Private
  - レバレッジアカウントの残高 GET /api/accounts/leverage_balance
  - ポジション一覧 GET /api/exchange/leverage/positions 
  - レバレッジアカウントへ振替 POST /api/exchange/transfers/to_leverage
  - レバレッジアカウントから振替 POST /api/exchange/transfers/from_leverage
